### PR TITLE
save/restore all register before doing a middle jump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ crate-type = ["cdylib"]
 version = "1.20"
 default-features = false
 # https://github.com/icedland/iced/blob/master/src/rust/iced-x86/README.md#crate-feature-flags
-features = ["std", "decoder", "fast_fmt", "instr_info"]
+features = ["std", "decoder", "fast_fmt", "instr_info", "code_asm"]
 
 [target."cfg(windows)".dev-dependencies.windows]
 version = "0.48"

--- a/src/arch/x86/thunk/x64.rs
+++ b/src/arch/x86/thunk/x64.rs
@@ -103,3 +103,47 @@ pub fn and_reg_i32_extended(register: Register, imm: i32) -> Box<dyn Thunkable> 
   bytes.extend_from_slice(&imm);
   Box::new(bytes)
 }
+
+pub fn push_all_regs() -> Box<dyn Thunkable> {
+  use iced_x86::code_asm::*;
+  let mut builder = CodeAssembler::new(64).unwrap();
+  builder.push(rsp).unwrap();
+  builder.push(rbp).unwrap();
+  builder.push(rax).unwrap();
+  builder.push(rbx).unwrap();
+  builder.push(rcx).unwrap();
+  builder.push(rdx).unwrap();
+  builder.push(rsi).unwrap();
+  builder.push(rdi).unwrap();
+  builder.push(r8).unwrap();
+  builder.push(r9).unwrap();
+  builder.push(r10).unwrap();
+  builder.push(r11).unwrap();
+  builder.push(r12).unwrap();
+  builder.push(r13).unwrap();
+  builder.push(r14).unwrap();
+  builder.push(r15).unwrap();
+  Box::new(builder.assemble(0x00).unwrap())
+}
+
+pub fn pop_all_regs() -> Box<dyn Thunkable> {
+  use iced_x86::code_asm::*;
+  let mut builder = CodeAssembler::new(64).unwrap();
+  builder.pop(r15).unwrap();
+  builder.pop(r14).unwrap();
+  builder.pop(r13).unwrap();
+  builder.pop(r12).unwrap();
+  builder.pop(r11).unwrap();
+  builder.pop(r10).unwrap();
+  builder.pop(r9).unwrap();
+  builder.pop(r8).unwrap();
+  builder.pop(rdi).unwrap();
+  builder.pop(rsi).unwrap();
+  builder.pop(rdx).unwrap();
+  builder.pop(rcx).unwrap();
+  builder.pop(rbx).unwrap();
+  builder.pop(rax).unwrap();
+  builder.pop(rbp).unwrap();
+  builder.pop(rsp).unwrap();
+  Box::new(builder.assemble(0x00).unwrap())
+}

--- a/src/arch/x86/thunk/x86.rs
+++ b/src/arch/x86/thunk/x86.rs
@@ -1,5 +1,5 @@
 use crate::pic::{FixedThunk, Thunkable};
-use generic_array::{typenum, GenericArray};
+use generic_array::{GenericArray, typenum};
 use std::mem;
 
 use super::Register;
@@ -115,4 +115,18 @@ pub fn and_reg_i32(register: Register, imm: i32) -> Box<dyn Thunkable> {
   let mut bytes = vec![opcode, mod_r_m];
   bytes.extend_from_slice(&imm);
   Box::new(bytes)
+}
+
+pub fn push_all_regs() -> Box<dyn Thunkable> {
+  use iced_x86::code_asm::*;
+  let mut builder = CodeAssembler::new(32).unwrap();
+  builder.pusha().unwrap();
+  Box::new(builder.assemble(0x00).unwrap())
+}
+
+pub fn pop_all_regs() -> Box<dyn Thunkable> {
+  use iced_x86::code_asm::*;
+  let mut builder = CodeAssembler::new(32).unwrap();
+  builder.popa().unwrap();
+  Box::new(builder.assemble(0x00).unwrap())
 }


### PR DESCRIPTION
Saving and Restoring all regs allow a more robust mid function implementation.